### PR TITLE
[Fixed] Same variable name, different scopes #5

### DIFF
--- a/OutCode.c
+++ b/OutCode.c
@@ -25,7 +25,6 @@ int main() {
         printf("%d\n", fibonacci(i));
 	printf("----\n");
     }
-	free(n);
 
 
 

--- a/ParseInject.py
+++ b/ParseInject.py
@@ -1,10 +1,8 @@
 import sys
 import json
+import parser
 
-import parser 
-
-
-def inject_deallocation_code(input_file, output_file, json_file):
+def inject_deallocation_code(input_file: str, output_file: str, json_file: str):
     print("Loading deallocation points from JSON file...")
     with open(json_file, 'r') as f:
         deallocation_data = json.load(f)
@@ -17,16 +15,34 @@ def inject_deallocation_code(input_file, output_file, json_file):
         source_code = f.readlines()
     print("Original source code read successfully.")
 
+    current_function = None
+    function_start_pattern = "{"
+    function_end_pattern = "}"
+    brace_count = 0
+
     with open(output_file, 'w') as f:
         print("Injecting deallocation code...")
         for i, line in enumerate(source_code, start=1):
+            # Track function scope
+            if "(" in line and ")" in line and "{" in line:
+                current_function = line.split("(")[0].strip().split()[-1]
+                brace_count = 1
+            elif "{" in line:
+                brace_count += line.count("{")
+            elif "}" in line:
+                brace_count -= line.count("}")
+                if brace_count == 0:
+                    current_function = None
+
             f.write(line)
-            #print(f"Processing line {i}...")
+            
             for deallocation_point in deallocation_points:
-                if i == deallocation_point['line_number']:
+                if (i == deallocation_point['line_number'] and 
+                    current_function == deallocation_point['function_name']):
                     variable_name = deallocation_point['variable_name']
-                    f.write(f'\tfree({variable_name});\n')  
-                    print(f"Freeing memory for variable {variable_name} at line {i}")
+                    f.write(f'\tfree({variable_name});\n')
+                    print(f"Freeing memory for variable {variable_name} at line {i} in function {current_function}")
+
         print("Deallocation code injected successfully.")
 
 if __name__ == "__main__":

--- a/parser.py
+++ b/parser.py
@@ -1,64 +1,96 @@
 import json
 from clang.cindex import CursorKind, Index
+from dataclasses import dataclass
+from typing import Dict, List, Set, Tuple
 
-deallocations = []
-references = {}
+@dataclass
+class VariableReference:
+    function_name: str
+    variable_name: str
+    line_number: int
 
+class ScopeTracker:
+    def __init__(self):
+        self.references: Dict[Tuple[str, str], VariableReference] = {}
+        self.deallocations: List[dict] = []
+        self.current_function: str = ""
 
-def traverse_ast(node, start_line=None,end_line = None):
+    def add_reference(self, var_name: str, line_number: int):
+        key = (self.current_function, var_name)
+        self.references[key] = VariableReference(
+            function_name=self.current_function,
+            variable_name=var_name,
+            line_number=line_number
+        )
+
+    def update_reference_line(self, var_name: str, new_line: int):
+        key = (self.current_function, var_name)
+        if key in self.references:
+            ref = self.references[key]
+            ref.line_number = new_line
+
+    def get_reference(self, var_name: str) -> VariableReference:
+        key = (self.current_function, var_name)
+        return self.references.get(key)
+
+def traverse_ast(node, scope_tracker: ScopeTracker, start_line=None, end_line=None):
+    if node.kind == CursorKind.FUNCTION_DECL:
+        scope_tracker.current_function = node.spelling
+
     if start_line is None:
         start_line = node.location.line
 
-    if node.kind == CursorKind.FOR_STMT or node.kind == CursorKind.WHILE_STMT:
+    if node.kind in (CursorKind.FOR_STMT, CursorKind.WHILE_STMT):
         start_line = node.location.line
         end_line = node.extent.end.line
 
     if node.kind == CursorKind.DECL_REF_EXPR:
         if node.referenced and node.referenced.kind == CursorKind.VAR_DECL:
             var_name = node.spelling
-            references[var_name] = node.location.line
+            scope_tracker.add_reference(var_name, node.location.line)
 
     for child in node.get_children():
-        traverse_ast(child, start_line, end_line)
+        traverse_ast(child, scope_tracker, start_line, end_line)
 
-    if node.kind == CursorKind.FOR_STMT or node.kind == CursorKind.WHILE_STMT:
-        for iterator in references.keys():
-            line_number = references[iterator]
-            if start_line <= line_number <= end_line:
-                references[iterator] = end_line
+    if node.kind in (CursorKind.FOR_STMT, CursorKind.WHILE_STMT):
+        for key, ref in scope_tracker.references.items():
+            if ref.function_name == scope_tracker.current_function:
+                if start_line <= ref.line_number <= end_line:
+                    scope_tracker.update_reference_line(ref.variable_name, end_line)
 
-
-def check_alloc_term(filename, line_number, var_name):
+def check_alloc_term(filename: str, line_number: int, var_name: str) -> bool:
     with open(filename, 'r') as f:
         lines = f.readlines()
         for i, line in enumerate(lines):
-            if ("alloc" in line): 
-                if (("*" + var_name) in line):
-                    return True
+            if "alloc" in line and f"*{var_name}" in line:
+                return True
     return False
 
-
-def main(input_file, json_file):
+def main(input_file: str, json_file: str):
     index = Index.create()
     tu = index.parse(input_file, args=['-std=c11'])
     print('Translation unit:', tu.spelling)
 
+    scope_tracker = ScopeTracker()
+
     for node in tu.cursor.get_children():
         if node.kind == CursorKind.FUNCTION_DECL:
-            traverse_ast(node)
+            traverse_ast(node, scope_tracker)
 
-    for iterator in references.keys():
-        references[iterator] = int(references[iterator])
-        line_number = references[iterator]
-        if check_alloc_term(input_file, line_number, iterator):
-            deallocations.append({"line_number": line_number, "variable_name": iterator})
+    # Process deallocations
+    for (func_name, var_name), ref in scope_tracker.references.items():
+        if check_alloc_term(input_file, ref.line_number, var_name):
+            scope_tracker.deallocations.append({
+                "function_name": func_name,
+                "line_number": ref.line_number,
+                "variable_name": var_name
+            })
 
     output = {
-        "deallocations": deallocations
+        "deallocations": scope_tracker.deallocations
     }
-    #print(deallocations)
 
-    if deallocations:
+    if scope_tracker.deallocations:
         with open(json_file, 'w') as f:
             json.dump(output, f, indent=4)
         print("Data written to references.json")

--- a/references.json
+++ b/references.json
@@ -1,10 +1,12 @@
 {
     "deallocations": [
         {
+            "function_name": "main",
             "line_number": 19,
             "variable_name": "x"
         },
         {
+            "function_name": "main",
             "line_number": 26,
             "variable_name": "n"
         }


### PR DESCRIPTION
Added a ScopeTracker class to manage variable references and deallocations

Created a VariableReference dataclass to store:
* Function name (scope)
* Variable name
* Line number
